### PR TITLE
feat(GSGGR-506): Notify about core extract changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: Notify changes
+on:
+  push:
+    tags:        
+      - '*'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v3.0.0
+      with:
+        token: ${{ secrets.DISPATCH_TOKEN }}
+        repository: https://api.github.com/repos/camptocamp/geoshop
+        event-type: extract_new_tag
+          


### PR DESCRIPTION
Tells that there was a new tag in the core extract and another repository should consider some action (e.g. build a new docker image).