### PR TITLE
feat(GSGGR-529): Allow using environment variables in the i18n strings.

### DIFF
--- a/extract/src/main/java/ch/asit_asso/extract/configuration/EnvResolvingMessageSource.java
+++ b/extract/src/main/java/ch/asit_asso/extract/configuration/EnvResolvingMessageSource.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 arusakov
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.asit_asso.extract.configuration;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringValueResolver;
+
+/**
+ * A MessageSource that resolves ${…} placeholders against the Spring {@link Environment}
+ * after the message has been loaded from the bundle.
+ */
+public class EnvResolvingMessageSource extends ReloadableResourceBundleMessageSource
+        implements EnvironmentAware {
+
+    private StringValueResolver placeholderResolver;
+
+    @Override
+    public void setEnvironment(Environment environment) {
+        // Spring already knows how to resolve ${…} against the environment,
+        // we just delegate to its built‑in resolver.
+        this.placeholderResolver = environment::resolveRequiredPlaceholders;
+    }
+
+    @Override
+    protected String resolveCodeWithoutArguments(String code, Locale locale) {
+        var raw = super.resolveCodeWithoutArguments(code, locale);
+        
+        return raw == null || placeholderResolver == null ? raw : 
+                placeholderResolver.resolveStringValue(raw);
+    }
+    
+    @Override
+    protected MessageFormat resolveCode(String code, Locale locale) {
+        var raw = super.resolveCode(code, locale);
+        if (raw != null && placeholderResolver != null) {
+            raw.applyPattern(placeholderResolver.resolveStringValue(raw.toPattern()));
+        }
+        return raw;
+    }
+}

--- a/extract/src/main/java/ch/asit_asso/extract/configuration/I18nConfiguration.java
+++ b/extract/src/main/java/ch/asit_asso/extract/configuration/I18nConfiguration.java
@@ -66,7 +66,7 @@ public class I18nConfiguration {
     @Bean
     public MessageSource messageSource() {
         this.logger.debug("Configuring the message source for language {}.", this.language);
-        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        EnvResolvingMessageSource messageSource = new EnvResolvingMessageSource();
         String basename = I18nConfiguration.DEFAULT_MESSAGES_BASENAME;
 
         if (this.language.matches("^[a-z]{2}$")) {


### PR DESCRIPTION
|Env variable|Result|
|------------------|---------|
|${QWERTY:default value}           |<img width="400" alt="Screenshot 2025-10-30 at 13-18-48 Extract" src="https://github.com/user-attachments/assets/8d5ce4e8-d875-4d88-ba92-f511531c550f" />|
|$HOME   |<img width="400" alt="Screenshot 2025-10-30 at 13-17-15 Extract" src="https://github.com/user-attachments/assets/2feb7234-4cb2-48b7-970e-0ad02e8fd9a1" />|
