### PR TITLE
Transform exported data to LV95

### DIFF
--- a/extract/src/main/resources/application.properties
+++ b/extract/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # Default properties for database persistence
-spring.datasource.url=jdbc:postgresql://pgsql:5432/extract
+spring.datasource.url=jdbc:postgresql://localhost:5432/extract
 spring.datasource.username=extractuser
 spring.datasource.password=demopassword
 spring.datasource.driver-class-name=org.postgresql.Driver

--- a/extract/src/main/resources/static/css/extract.css
+++ b/extract/src/main/resources/static/css/extract.css
@@ -565,6 +565,11 @@ table.list-table.files-list-table {
     bottom: 0.5em;
 }
 
+.lv95 {
+    right: 8.5em;
+    bottom: 0.5em;
+}
+
 .export-kml {
     right: 4.5em;
     bottom: 0.5em;

--- a/extract/src/main/resources/static/css/extract.css
+++ b/extract/src/main/resources/static/css/extract.css
@@ -581,7 +581,7 @@ table.list-table.files-list-table {
 }
 
 .ol-control.ol-attribution {
-    right: 8.5em;
+    right: 15.5em;
 }
 
 .ol-attribution.ol-uncollapsible ~ .ol-control.export-button {

--- a/extract/src/main/resources/static/js/requestDetails.js
+++ b/extract/src/main/resources/static/js/requestDetails.js
@@ -370,7 +370,7 @@ class ExportToDxfControl extends ol.control.Control {
         button.title = options.tooltip;
 
         var element = document.createElement('div');
-        element.className = `${options.style || "export-dxf"} export-button ol-unselectable ol-control`;
+        element.className = `${options.styleClass || "export-dxf"} export-button ol-unselectable ol-control`;
         element.appendChild(button);
 
         super({

--- a/extract/src/main/resources/static/js/requestDetails.js
+++ b/extract/src/main/resources/static/js/requestDetails.js
@@ -239,6 +239,12 @@ function _initializeExportButtons(map) {
         label: LANG_MESSAGES.requestDetails.exportToKml.label,
         tooltip: LANG_MESSAGES.requestDetails.exportToKml.tooltip
     }));
+    map.addControl(new ExportToDxfControl({
+        label: `${LANG_MESSAGES.requestDetails.exportToDxf.label} (LV95)`,
+        tooltip: `${LANG_MESSAGES.requestDetails.exportToDxf.tooltip} (LV95)`,
+        projection: "EPSG:2056",
+        css:"lv95"
+    }));
 }
 
 
@@ -365,6 +371,9 @@ class ExportToDxfControl extends ol.control.Control {
 
         var element = document.createElement('div');
         element.className = 'export-dxf export-button ol-unselectable ol-control';
+        if (options.css) {
+            element.className += " " + options.css;
+        }
         element.appendChild(button);
 
         super({
@@ -375,11 +384,10 @@ class ExportToDxfControl extends ol.control.Control {
         button.addEventListener('click', this.handleExportToDxf.bind(this), false);
         button.addEventListener('touchstart', this.handleExportToDxf.bind(this), false);
         this.DxfGlobalHandle = 2000;
+        this.projection = options.projection || "";
     }
 
     buildDxfPolyline(ring) {
-        console.log(ring);
-
         this.DxfGlobalHandle++;
         var pointsCount = ring.length;
         var dxfPolygon = '  0\n' +
@@ -1687,15 +1695,16 @@ class ExportToDxfControl extends ol.control.Control {
 
         return parseInt(number, 10).toString(16);
     }
-
+    
     getLinearRingsFromFeatures(features) {
-        console.log(features);
-
         var rings = [];
 
         for (var i = 0; i < features.length; i++) {
             var feature = features[i];
-            var geometry = feature.getGeometry();
+            var geometry = feature.getGeometry().clone();
+            if (this.projection) {
+                geometry.transform('EPSG:3857', this.projection);
+            }
 
             if (geometry instanceof ol.geom.MultiPolygon) {
                 var polygons = geometry.getPolygons();

--- a/extract/src/main/resources/static/js/requestDetails.js
+++ b/extract/src/main/resources/static/js/requestDetails.js
@@ -243,7 +243,7 @@ function _initializeExportButtons(map) {
         label: `${LANG_MESSAGES.requestDetails.exportToDxf.label} (LV95)`,
         tooltip: `${LANG_MESSAGES.requestDetails.exportToDxf.tooltip} (LV95)`,
         projection: "EPSG:2056",
-        css:"lv95"
+        styleClass: "lv95"
     }));
 }
 
@@ -370,10 +370,7 @@ class ExportToDxfControl extends ol.control.Control {
         button.title = options.tooltip;
 
         var element = document.createElement('div');
-        element.className = 'export-dxf export-button ol-unselectable ol-control';
-        if (options.css) {
-            element.className += " " + options.css;
-        }
+        element.className = `${options.style || "export-dxf"} export-button ol-unselectable ol-control`;
         element.appendChild(button);
 
         super({

--- a/extract/src/main/resources/static/js/requestMap/map.js
+++ b/extract/src/main/resources/static/js/requestMap/map.js
@@ -15,13 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-function initializeMap() {
+function registerProjections() {
     proj4.defs("EPSG:2056",
     '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333'
     + ' +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel '
     + '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
     ol.proj.proj4.register(proj4);
-        
+}
+
+function initializeMap() {
+    registerProjections();
+
     return new Promise(function(resolve, reject) {
         const attribution = new ol.control.Attribution({
             collapsible: true,

--- a/extract/src/main/resources/static/js/requestMap/map.js
+++ b/extract/src/main/resources/static/js/requestMap/map.js
@@ -16,7 +16,12 @@
  */
 
 function initializeMap() {
-    
+    proj4.defs("EPSG:2056",
+    '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333'
+    + ' +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel '
+    + '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
+    ol.proj.proj4.register(proj4);
+        
     return new Promise(function(resolve, reject) {
         const attribution = new ol.control.Attribution({
             collapsible: true,


### PR DESCRIPTION
Added a button for exporting DXF files in LV95 (EPSG:2056) format.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/f44013c9-d2de-4451-bcdd-626ee5a9c5d6" />

An improvement before adding an advanced exporting dialog:
<img width="500" alt="Screenshot 2026-05-18 at 11-15-52 Extract – Détails de la demande 7 - Commande devisée pour test _ Maquette 3D" src="https://github.com/user-attachments/assets/637c0fb2-888f-49c6-99d9-2224d9d4c329" />
